### PR TITLE
Updated types and fixed deprecation of Buffer().

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dltreader",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -47,9 +47,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-      "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
+      "version": "10.17.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.29.tgz",
+      "integrity": "sha512-zLo9rjUeQ5+QVhOufDwrb3XKyso31fJBJnk9wUUQIBDExF/O4LryvpOfozfUaxgqifTnlt7FyqsAPXUq5yFZSA==",
       "dev": true
     },
     "ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Dmitry Astafyev (dmitry.astafyev@esrlabs.com)",
   "license": "Apache 2",
   "devDependencies": {
-    "@types/node": "^10.12.0",
+    "@types/node": "^10.17.29",
     "jasmine": "^3.6.1",
     "jasmine-ts": "^0.3.0",
     "ts-node": "^7.0.0",

--- a/src/dlt.buffer.ts
+++ b/src/dlt.buffer.ts
@@ -12,7 +12,7 @@ export default class DLTBuffer extends EventEmitter {
         error: 'error',
     };
 
-    private _buffer: Buffer = new Buffer(0);
+    private _buffer: Buffer = Buffer.alloc(0);
 
     constructor() {
         super();
@@ -43,7 +43,7 @@ export default class DLTBuffer extends EventEmitter {
 
     public destroy() {
         // Drop buffer
-        this._buffer = new Buffer(0);
+        this._buffer = Buffer.alloc(0);
     }
 
     private _read(): DLTError | IPacketData | undefined {

--- a/src/dlt.stream.transform.ts
+++ b/src/dlt.stream.transform.ts
@@ -31,7 +31,7 @@ export default class DLTFileReadStream extends Transform {
         error: 'error',
     };
 
-    private _buffer: Buffer = new Buffer(0);
+    private _buffer: Buffer = Buffer.alloc(0);
     private _header: Header | undefined;
     private _packets: number = 0;
     private _bytes: number = 0;


### PR DESCRIPTION
Changed buffer initialization due to pointed out deprecation:
`[DEP0005] DeprecationWarning: The Buffer() and new Buffer() constructors are not recommended for use due to security and usability concerns. Please use the new Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() construction methods instead.`

Now after bundle, warning is gone. 